### PR TITLE
checkpoint-timeout feature

### DIFF
--- a/src/co/nclk/linen/core.clj
+++ b/src/co/nclk/linen/core.clj
@@ -406,7 +406,8 @@
     (let [effective (java.util.Date. (long (:effective config)))
           config (assoc config :effective effective
                                :runnable? (atom true)
-                               :node-manager (node-manager effective callbacks)
+                               :node-manager (node-manager effective callbacks
+                                               :timeout (:node-manager-timeout config))
                                :genv (or (:genv config) genv)
                                :failed? (promise))
           {module :main


### PR DESCRIPTION
Looks for a `timeout` entry on the checkpoint, then a `timeout` entry on the node (initialized by its generator module), and finally defaults to 15 minutes.